### PR TITLE
Move docker-compose.yml in and don't run build on create

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: guysoft/custompios:devel
     env_file: .env
     container_name: ${DISTRO_NAME}-build
-    command: /distro/src/build_dist
+    #command: /distro/src/build_dist
     tty: true
     restart: always
     privileged: true


### PR DESCRIPTION
This builds, I could get your this to build without it.

Use the build command:
```
docker exec -it RTSPiOS-build /CustomPiOS/nightly_build_scripts/custompios_nightly_build
```

And create an ``.env`` with the right string